### PR TITLE
[COOK-4560] Attribute to disable ChefVault

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ this cookbook, but is used in the helper.
   testing, and not as a fall back to avoid issues loading encrypted
   items.
 
+* `node['disable_chef_vault']` - If this is true, `chef_vault_item` will attempt
+  to load the specified item as an Encrypted Data Bag Item with
+  `Chef::EncryptedDataBagItem.load`. This is intended to allow both usages of 
+  encrypted data bags with one solution.
+
 ## Usage
 
 Include the recipe before using the Chef Vault library in recipes.

--- a/libraries/chef_vault_item.rb
+++ b/libraries/chef_vault_item.rb
@@ -39,6 +39,8 @@ class Chef
 
       if node['dev_mode']
         Chef::DataBagItem.load(bag, item)
+      elsif node['disable_chef_vault']
+        Chef::EncryptedDataBagItem.load(bag, item)
       else
         ChefVault::Item.load(bag, item)
       end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-4560

As odd as this option might sound, I think it's worth moving towards one solution that allows use for either chef-vault, or built-in Chef::EncryptedDataBagItem objects.

Example would be chef-splunk cookbook.  It uses chef-vault, so those not using ChefVault would have to implement wrappers just to disable the vault usage.  Whereas this option would make both parties happy.
