### PR TITLE
Allow chef_vault_item to fall back to data bags

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,8 +20,6 @@ suites:
   run_list:
   - recipe[chef-vault]
   - recipe[test]
-  attributes:
-    dev_mode: true
 
 - name: secret_resource
   run_list:

--- a/README.md
+++ b/README.md
@@ -30,23 +30,18 @@ Instead of:
 
     ChefVault::Item.load("secrets", "dbpassword")
 
-This has logic to allow for development and testing of recipes, see
-__Attributes__ below.
+This has logic in place to fall back to using data bags if the desired item
+isn't encrypted. If the vault item fails to load because of missing vault
+metadata (a `vaultname_keys` data bag), then `chef_vault_item` will attempt to
+load the specified item as a regular Data Bag Item with
+`Chef::DataBagItem.load`. This is intended to be used only for testing, and
+not as a fall back to avoid issues loading encrypted items.
 
 ## Attributes
 
 * `node['chef-vault']['version']` - Specify a version of the
   chef-vault gem if required. Default is `nil`, so the latest version
   will be installed.
-
-The following attribute is special and not specifically related to
-this cookbook, but is used in the helper.
-
-* `node['dev_mode']` - If this is true, `chef_vault_item` will attempt
-  to load the specified item as a regular Data Bag Item with
-  `Chef::DataBagItem.load`. This is intended to be used only for
-  testing, and not as a fall back to avoid issues loading encrypted
-  items.
 
 ## Resources
 

--- a/libraries/chef_vault_item.rb
+++ b/libraries/chef_vault_item.rb
@@ -28,8 +28,8 @@ class Chef
     # Instead of:
     #   ChefVault::Item.load("secrets", "dbpassword")
     #
-    # optionally set `node['dev_mode']` to true to fall back to normal
-    # data bag item loading.
+    # Falls back to normal data bag item loading if the item isn't actually a
+    # vault item.
     def chef_vault_item(bag, item)
       begin
         require 'chef-vault'
@@ -37,10 +37,10 @@ class Chef
         Chef::Log.warn("Missing gem 'chef-vault', use recipe[chef-vault] to install it first.")
       end
 
-      if node['dev_mode']
-        Chef::DataBagItem.load(bag, item)
-      else
+      begin
         ChefVault::Item.load(bag, item)
+      rescue ChefVault::Exceptions::KeysNotFound
+        Chef::DataBagItem.load(bag, item)
       end
     end
   end


### PR DESCRIPTION
Fixes #6

This allows cookbooks that use chef_vault_item to work transparently in
situations where chef vault isn't yet in use, such as development/staging
environments, without any changes. This change replaces the 'dev_mode'
attribute that was previously requires for chef_vault_item to use unencrypted
data bags instead.
