### PR TITLE
Fix match expression in tests

### DIFF
--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -2,6 +2,6 @@ require_relative '../../../kitchen/data/spec_helper'
 
 describe 'chef-vault::default' do
   describe file('/tmp/chef-vault-secret') do
-    its(:content) { should match('/success/') }
+    its(:content) { should match(/success/) }
   end
 end


### PR DESCRIPTION
The test fails for me currently, despite the content of the file actually being 'success'. It looks like it's trying to match a literal '/success/' (without quotes) rather than treating it as a regular expression.
