### PR TITLE
Set a default version of chef-vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Chef.
 This cookbook is specifically tested on Ubuntu and CentOS platforms
 using Test Kitchen. See `.kitchen.yml` for platforms and test suites.
 
+The helper methods in this cookbook use the Chef Vault v2 API, so the
+default version will match `~> 2.2` to ensure a reasonably updated
+version of the gem is installed.
+
 ## Helper Method
 
 This cookbook provides a nice helper method for the Chef Recipe DSL so
@@ -36,8 +40,8 @@ __Attributes__ below.
 ## Attributes
 
 * `node['chef-vault']['version']` - Specify a version of the
-  chef-vault gem if required. Default is `nil`, so the latest version
-  will be installed.
+  chef-vault gem if required. Default is `~> 2.2`, as that version was
+  used for testing.
 
 The following attribute is special and not specifically related to
 this cookbook, but is used in the helper.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,5 +17,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Set this if you need a specific version of chef-vault
-default['chef-vault']['version'] = nil
+default['chef-vault']['version'] = '~> 2.2'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -2,6 +2,6 @@ require_relative '../../../kitchen/data/spec_helper'
 
 describe 'chef-vault::default' do
   describe file('/tmp/chef-vault-secret') do
-    its(:content) { should match('/success/') }
+    its(:content) { should match(/success/) }
   end
 end


### PR DESCRIPTION
The version of chef-vault needs to be set to a sane default, where "sane" is
defined by:

```
A version of chef-vault that has the API we use in the helpers.
```

The current release is 2.2.4, which will be installed on new systems. However,
if a system had e.g. `1.2.5`, it wouldn't have the ChefVault::Item class used
by the `chef_vault_item` helper.
