### PR TITLE
Use the new ::vault? predicate in chef-vault 2.6 

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-default['chef-vault']['version'] = '~> 2.2'
+default['chef-vault']['version'] = '~> 2.6'
 default['chef-vault']['databag_fallback'] = true
 default['chef-vault']['gem_source'] = nil

--- a/libraries/chef_vault_item.rb
+++ b/libraries/chef_vault_item.rb
@@ -30,13 +30,12 @@ module ChefVaultItem
   # Falls back to normal data bag item loading if the item isn't actually a
   # vault item.
   def chef_vault_item(bag, item)
-    if Chef::DataBag.load(bag).key?("#{item}_keys")
-      # We have a vault item
-      begin
-        require 'chef-vault'
-      rescue LoadError
-        raise("Missing gem 'chef-vault', use recipe[chef-vault] to install it first.")
-      end
+    begin
+      require 'chef-vault'
+    rescue LoadError
+      raise("Missing gem 'chef-vault', use recipe[chef-vault] to install it first.")
+    end
+    if ChefVault::Item.vault?(bag, item)
       ChefVault::Item.load(bag, item)
     else
       # We don't have a vault item, it must be a regular data bag


### PR DESCRIPTION
to decide whether to fall back or not.

The upside is that when we rewrite chef-vault for 2.6, whether something is or is not a vault will be based on whatever the active plugin is, so the existence of a _keys databag may no longer be the right test.  By encouraging people to use the public API, this test can be delegated to plugins and should work regardless of what the keying implementation is.

Downside: you have to install chef-vault to use the predicate method, even if you are only going to hit a normal data bag.

I also had to do some test-kitchen fixups to get this to verify, but I didn't want to bloat the PR.  I can put these in another PR, but the necessary changes were:
- centos-5.9 and 6.4 are no longer available as Bento boxes (or use such an old version of chef-client that --local-mode doesn't work), so I tested with 6.6 and 7.0
- the platform_family on centos returns 'rhel', not 'redhat', so that needed to be added to the package resource in the testing recipe - otherwise it tries to install openssl-dev and fails

Having made those changes, I did get clean TK results from ubuntu 10/12/14 and cent-6.6/7.0
