### PR TITLE
`join_commas` now returns a joined string instead of array

### DIFF
--- a/libraries/chef_vault_secret_provider.rb
+++ b/libraries/chef_vault_secret_provider.rb
@@ -89,7 +89,6 @@ class Chef::Provider::ChefVaultSecret < Chef::Provider::LWRPBase
     when Array
       admins.join(',')
     end
-    admins
   end
 
   def vault_item_exists?


### PR DESCRIPTION
I have been pulling my hair out trying to figure out why I was getting this crazy error when I specified admins as an array - `NoMethodError: undefined method `split' for ["admin1", "admin2]:Array`

This was a tricky one to find. Just remove the one line and now everything is happy :+1:
