### PR TITLE
Fix "uninitialized constant" error

### DIFF
--- a/libraries/chef_vault_secret.rb
+++ b/libraries/chef_vault_secret.rb
@@ -54,7 +54,8 @@ module ChefVaultCookbook
 
       def load_current_resource
         json = ChefVault::Item.load(new_resource.data_bag, new_resource.id)
-        @current_resource = Chef::Resource::ChefVaultSecret.new(new_resource.id)
+        @current_resource =
+          ChefVaultCookbook::Resource::ChefVaultSecret.new(new_resource.id)
         @current_resource.search(new_resource.search)
         @current_resource.admins(new_resource.admins)
         @current_resource.data_bag(new_resource.data_bag)


### PR DESCRIPTION
This commit removes a reference to Chef::Resource::ChefVaultSecret in order to avoid an uninitialized constant error.


```
error: NameError: uninitialized constant Chef::Resource::ChefVaultSecret
  
  Cookbook Trace:
  ---------------
    /var/chef/cache/cookbooks/chef-vault/libraries/chef_vault_secret.rb:58:in `load_current_resource'
    /var/chef/cache/cookbooks/bcpc/recipes/cobbler.rb:43:in `from_file'
  
  Relevant File Content:
  ----------------------
  /var/chef/cache/cookbooks/chef-vault/libraries/chef_vault_secret.rb:
  
   51:  
   52:        def whyrun_supported?
   53:          true
   54:        end
   55:  
   56:        def load_current_resource
   57:          json = ChefVault::Item.load(new_resource.data_bag, new_resource.id)
   58>>         @current_resource = Chef::Resource::ChefVaultSecret.new(new_resource.id)
   59:          @current_resource.search(new_resource.search)
   60:          @current_resource.admins(new_resource.admins)
   61:          @current_resource.data_bag(new_resource.data_bag)
   62:          @current_resource.raw_data(json.to_hash)
   63:          @current_resource
   64:        rescue ChefVault::Exceptions::KeysNotFound
   65:          @current_resource = nil
   66:        rescue Net::HTTPServerException => e
   67:          @current_resource = nil if e.response_code == '404'
```