### PR TITLE
Add support for alternative chef-vault node_name and client_key_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ _Store
 _yardoc
 doc/
 .idea
+*.iml
 
 #chef stuff
 Berksfile.lock

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -34,7 +34,12 @@ module ChefVaultCookbook
   # @param [String] id Identifier of the data bag item to load.
   def chef_vault_item(bag, id)
     if ChefVault::Item.vault?(bag, id)
-      ChefVault::Item.load(bag, id)
+      auth_params = {}
+      if node['chef-vault']['node_name']
+        auth_params[:node_name] = node['chef-vault']['node_name']
+        auth_params[:client_key_path] = node['chef-vault']['client_key_path']
+      end
+      ChefVault::Item.load(bag, id, auth_params)
     elsif node['chef-vault']['databag_fallback']
       Chef::DataBagItem.load(bag, id)
     else


### PR DESCRIPTION
There is probably a better way for this.  I can't figure out how to change test-kitchen's client.rb with a node_name and client_key_path for my encrypted data bag items.  I've been using the authentication overwrite params for ChefVault::Item.load() but the chef-splunk uses the 'chef_vault_item' helper natively.

This fork allowed me to define the alternative authentication by just setting node properties.   
