### PR TITLE
Fix for "Data Bag Items must contain a Hash or Mash!" introduced in 1.3.1

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -33,7 +33,7 @@ module ChefVaultCookbook
   # @param [String] bag Name of the data bag to load from.
   # @param [String] id Identifier of the data bag item to load.
   def chef_vault_item(bag, id)
-    if ChefVault::Item.vault?(bag, id)
+    if Chef::DataBag.load(bag).key?("#{id}_keys")
       ChefVault::Item.load(bag, id)
     elsif node['chef-vault']['databag_fallback']
       Chef::DataBagItem.load(bag, id)


### PR DESCRIPTION
I really don't think this is the proper fix for the problem brought up in #20, but I can tell you these facts:
- chef-vault 1.3.0 worked fine in our chefspec tests for our cookbooks
- chef-vault 1.3.1 introduced the problem mentioned in the issue above
- reverting back to 1.3.0 without changing anything else allowed chefspec to pass

I looked at the changes in helper.rb between releases, and came up with this hack which works in our case.  I don't think this is the proper fix, rather I just wanted to point out something that worked so that someone more familiar with chef-vault cookbook, chef-vault, and chef could get a head start on finding the bug.
