### PR TITLE
Client discovery should default to the search query

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ declarative state. To get the `knife vault create` behavior, use
   Corresponds to the "admin" option when using the chef-vault knife
   plugin. Can be specified as a comma separated string or an array.
   See examples, below.
-* `clients` - A search query for the nodes' API clients that should
-  have access to the item.
+* `clients` - Either a Chef::ApiClient object or a search query for the nodes' API clients that should
+  have access to the item. Defaults to using the query specified for `search` 
 * `search` - Search query that would match the same used for the
   clients, gets stored as a field in the item.
 * `raw_data` - The raw data, as a Ruby Hash, that will be stored in

--- a/libraries/chef_vault_secret.rb
+++ b/libraries/chef_vault_secret.rb
@@ -84,7 +84,7 @@ module ChefVaultCookbook
           Chef::Log.debug("#{new_resource.id} search query: '#{new_resource.search}'")
           item.search(new_resource.search)
           if new_resource.clients.nil?
-            Chef::Log.debug("No clients specified. Using search query to discover clients")
+            Chef::Log.debug('No clients specified. Using search query to discover clients')
             item.clients(new_resource.search)
           else
             Chef::Log.debug("#{new_resource.id} clients: '#{new_resource.clients}'")

--- a/libraries/chef_vault_secret.rb
+++ b/libraries/chef_vault_secret.rb
@@ -83,8 +83,13 @@ module ChefVaultCookbook
 
           Chef::Log.debug("#{new_resource.id} search query: '#{new_resource.search}'")
           item.search(new_resource.search)
-          Chef::Log.debug("#{new_resource.id} clients: '#{new_resource.clients}'")
-          item.clients([new_resource.clients].flatten.join(',')) unless new_resource.clients.nil?
+          if new_resource.clients.nil?
+            Chef::Log.debug("No clients specified. Using search query to discover clients")
+            item.clients(new_resource.search)
+          else
+            Chef::Log.debug("#{new_resource.id} clients: '#{new_resource.clients}'")
+            item.clients([new_resource.clients].flatten.join(','))
+          end
           Chef::Log.debug("#{new_resource.id} admins (users): '#{new_resource.admins}'")
           item.admins([new_resource.admins].flatten.join(','))
           item.save


### PR DESCRIPTION
Let's DRY out the search for clients. Rather than specify the same search query for `clients` and `search`, let the clients search default to the one specified by the `search` attribute.
