### PR TITLE
Fix custom gem source being ignored

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/AbcSize:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -38,7 +38,7 @@ module ChefVaultCookbook
     elsif node['chef-vault']['databag_fallback']
       Chef::DataBagItem.load(bag, id)
     else
-      fail "Trying to load a regular data bag item #{id} from #{bag}, and databag_fallback is disabled"
+      raise "Trying to load a regular data bag item #{id} from #{bag}, and databag_fallback is disabled"
     end
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,12 +23,18 @@ if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
     source node['chef-vault']['gem_source']
     version node['chef-vault']['version']
     compile_time true
+    if node['chef-vault']['gem_source'] != nil
+        clear_sources true
+    end
   end
 else
   chef_gem 'chef-vault' do
     source node['chef-vault']['gem_source']
     version node['chef-vault']['version']
     action :nothing
+    if node['chef-vault']['gem_source'] != nil
+        clear_sources true
+    end
   end.run_action(:install)
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,18 +23,14 @@ if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
     source node['chef-vault']['gem_source']
     version node['chef-vault']['version']
     compile_time true
-    if node['chef-vault']['gem_source'] != nil
-        clear_sources true
-    end
+    clear_sources true if !node['chef-vault']['gem_source'].nil?
   end
 else
   chef_gem 'chef-vault' do
     source node['chef-vault']['gem_source']
     version node['chef-vault']['version']
     action :nothing
-    if node['chef-vault']['gem_source'] != nil
-        clear_sources true
-    end
+    clear_sources true if !node['chef-vault']['gem_source'].nil?
   end.run_action(:install)
 end
 


### PR DESCRIPTION
As per https://docs.chef.io/resource_chef_gem.html#properties

If we don't clear the sources rubygems.org is still used.
This leads to failures in locked down environments where the Internet is not directly reachable.