### PR TITLE
Fix custom gem sources being ignored

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/AbcSize:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -38,7 +38,7 @@ module ChefVaultCookbook
     elsif node['chef-vault']['databag_fallback']
       Chef::DataBagItem.load(bag, id)
     else
-      fail "Trying to load a regular data bag item #{id} from #{bag}, and databag_fallback is disabled"
+      raise "Trying to load a regular data bag item #{id} from #{bag}, and databag_fallback is disabled"
     end
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,12 +22,14 @@ if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
   chef_gem 'chef-vault' do # ~FC009
     source node['chef-vault']['gem_source']
     version node['chef-vault']['version']
+    clear_sources true unless node['chef-vault']['gem_source'].nil?
     compile_time true
   end
 else
   chef_gem 'chef-vault' do
     source node['chef-vault']['gem_source']
     version node['chef-vault']['version']
+    clear_sources true unless node['chef-vault']['gem_source'].nil?
     action :nothing
   end.run_action(:install)
 end


### PR DESCRIPTION
As per https://docs.chef.io/resource_chef_gem.html#properties
If we don't clear the sources, Rubygems is still used.
This leads to failures in locked down environments where the Internet is not directly reachable.