### PR TITLE
Fix delete action to pass data_bag property

### DIFF
--- a/libraries/chef_vault_secret.rb
+++ b/libraries/chef_vault_secret.rb
@@ -100,10 +100,12 @@ module ChefVaultCookbook
       action :delete do
         converge_by("remove #{new_resource.id} and #{new_resource.id}_keys from #{new_resource.data_bag}") do
           chef_data_bag_item new_resource.id do
+            data_bag new_resource.data_bag
             action :delete
           end
 
           chef_data_bag_item [new_resource.id, 'keys'].join('_') do
+            data_bag new_resource.data_bag
             action :delete
           end
         end


### PR DESCRIPTION
### Description

`chef_vault_secret` requires `data_bag` so we pass that into `chef_data_bag_item`

### Issues Resolved

Fixes #45 

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


