### PR TITLE
Remove compat_resource; we don't need it anymore

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,5 +10,4 @@ source_url 'https://github.com/chef-cookbooks/chef-vault'
 issues_url 'https://github.com/chef-cookbooks/chef-vault/issues'
 chef_version '>= 12.9'
 
-depends 'compat_resource', '>= 12.16.3'
 gem 'chef-vault'


### PR DESCRIPTION
### Description

Get rid of `compat_resource` as this cookbook is now advertised to need Chef >= 12.9

### Issues Resolved

None

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
