### PR TITLE
Add `chef_vault()` helper method to efficiently list items in a vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Instead of (or any combination of such expression):
 item = chef_vault_item('secrets', 'passwords')[node.chef_environment]
 ```
 
+In addition, you can list the items in a vault using the `chef_vault()` method.
+It is advised to use this method instead of `data_bag()`, because the latter
+returns the keys in addition to the items themselves. This method prevents you
+from having to parse out the keys.
+```ruby
+items = chef_vault('secrets')
+item = chef_vault_item('secrets',item[0])
+```
+
 ## Attributes
 
 * `node['chef-vault']['version']` - Specify a version of the

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -53,15 +53,22 @@ module ChefVaultCookbook
   # log 'Yeah buddy!' if ids[0] == 'bacon'
   # @param [String] bag Name of the data bag to load from.
   # @return [Array]
+  #  def chef_vault(bag)
+  #    items = []
+  #    raise "'#{bag}' is not a vault" unless Chef::DataBag.list.include? bag
+  #    pattern = Regexp.new(/_keys/).freeze
+  #    data_bag(bag).each do |id|
+  #      next if pattern.match?(id)
+  #      items << id
+  #    end
+  #    items
+  #  end
   def chef_vault(bag)
-    items = []
     raise "'#{bag}' is not a vault" unless Chef::DataBag.list.include? bag
-    data_bag(bag).each do |id|
-      pattern = Regexp.new(/_keys/).freeze
-      next if pattern.match?(id)
-      items << id
+    pattern = Regexp.new(/_keys$/).freeze
+    data_bag(bag).each_with_object([]) do |id, acc|
+      acc << id unless pattern.match?(id)
     end
-    items
   end
 
   # Helper method which provides an environment wrapper for a data bag.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -55,16 +55,13 @@ module ChefVaultCookbook
   # @return [Array]
   def chef_vault(bag)
     items = []
-    if Chef::DataBag.list.include? bag
-      data_bag(bag).each do |id|
-        pattern = Regexp.new(/_keys/).freeze
-        next if pattern.match?(id)
-        items << id
-      end
-      items
-    else
-      raise "'#{bag}' is not a vault"
+    raise "'#{bag}' is not a vault" unless Chef::DataBag.list.include? bag
+    data_bag(bag).each do |id|
+      pattern = Regexp.new(/_keys/).freeze
+      next if pattern.match?(id)
+      items << id
     end
+    items
   end
 
   # Helper method which provides an environment wrapper for a data bag.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -44,6 +44,29 @@ module ChefVaultCookbook
     end
   end
 
+  # Helper method that allows for listing the ids of a vault in a recipe.
+  # This method is needed because data_bag() returns the keys along with
+  # the items, so this method strips out the keys for users so that they
+  # don't have to do it in their recipes.
+  # @example
+  # ids = chef_vault('secrets')
+  # log 'Yeah buddy!' if ids[0] == 'bacon'
+  # @param [String] bag Name of the data bag to load from.
+  # @return [Array]
+  def chef_vault(bag)
+    items = []
+    if Chef::DataBag.list.include? bag
+      data_bag(bag).each do |id|
+        pattern = Regexp.new(/_keys/).freeze
+        next if pattern.match?(id)
+        items << id
+      end
+      items
+    else
+      raise "'#{bag}' is not a vault"
+    end
+  end
+
   # Helper method which provides an environment wrapper for a data bag.
   # This allows for easy access to current environment secrets inside
   # of an item.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -53,16 +53,6 @@ module ChefVaultCookbook
   # log 'Yeah buddy!' if ids[0] == 'bacon'
   # @param [String] bag Name of the data bag to load from.
   # @return [Array]
-  #  def chef_vault(bag)
-  #    items = []
-  #    raise "'#{bag}' is not a vault" unless Chef::DataBag.list.include? bag
-  #    pattern = Regexp.new(/_keys/).freeze
-  #    data_bag(bag).each do |id|
-  #      next if pattern.match?(id)
-  #      items << id
-  #    end
-  #    items
-  #  end
   def chef_vault(bag)
     raise "'#{bag}' is not a vault" unless Chef::DataBag.list.include? bag
     pattern = Regexp.new(/_keys$/).freeze

--- a/test/fixtures/cookbooks/test/libraries/test_chef_vault_library.rb
+++ b/test/fixtures/cookbooks/test/libraries/test_chef_vault_library.rb
@@ -1,12 +1,18 @@
 module TestChefVaultLibrary
-  def test_chef_vault
+  def test_chef_vault_item
     chef_vault_item('secrets', 'dbpassword')
   end
 
+  def test_chef_vault
+    chef_vault('secrets')
+  end
+  
   def test_chef_vault_for_environment
     chef_vault_item_for_environment('secrets', 'bacon')
   end
 end
+
+  
 
 class Chef::Recipe; include TestChefVaultLibrary; end
 class Chef::Resource; include TestChefVaultLibrary; end

--- a/test/fixtures/cookbooks/test/libraries/test_chef_vault_library.rb
+++ b/test/fixtures/cookbooks/test/libraries/test_chef_vault_library.rb
@@ -6,13 +6,11 @@ module TestChefVaultLibrary
   def test_chef_vault
     chef_vault('secrets')
   end
-  
+
   def test_chef_vault_for_environment
     chef_vault_item_for_environment('secrets', 'bacon')
   end
 end
-
-  
 
 class Chef::Recipe; include TestChefVaultLibrary; end
 class Chef::Resource; include TestChefVaultLibrary; end

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -58,11 +58,11 @@ end
 items = chef_vault('secrets')
 
 file '/tmp/chef-vault-items' do
-  content items.join(",")
+  content items.join(',')
 end
 
 library_items = test_chef_vault
 
 file '/tmp/chef-vault-items-from-library' do
-  content library_items.join(",")
+  content library_items.join(',')
 end

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -25,7 +25,7 @@ file '/tmp/chef-vault-secret' do
   content secret['auth']
 end
 
-library_secret = test_chef_vault
+library_secret = test_chef_vault_item
 
 file '/tmp/chef-vault-secret-from-library' do
   content library_secret['auth']
@@ -53,4 +53,16 @@ end
 library_secret = test_chef_vault_for_environment
 file '/tmp/chef-vault-environment-secret-from-library' do
   content library_secret['type']
+end
+
+items = chef_vault('secrets')
+
+file '/tmp/chef-vault-items' do
+  content items.join(",")
+end
+
+library_items = test_chef_vault
+
+file '/tmp/chef-vault-items-from-library' do
+  content library_items.join(",")
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -19,3 +19,11 @@ end
 describe file('/tmp/chef-vault-environment-secret-from-library') do
   its(:content) { should match(/unicorn/) }
 end
+
+describe file('/tmp/chef-vault-items') do
+  its(:content) { should match(/exception raised/) }
+end
+
+describe file('/tmp/chef-vault-items-from-library') do
+  its(:content) { should match(/unicorn/) }
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -21,9 +21,9 @@ describe file('/tmp/chef-vault-environment-secret-from-library') do
 end
 
 describe file('/tmp/chef-vault-items') do
-  its(:content) { should match(/exception raised/) }
+  its(:content) { should match(/bacon,dbpassword/) }
 end
 
 describe file('/tmp/chef-vault-items-from-library') do
-  its(:content) { should match(/unicorn/) }
+  its(:content) { should match(/bacon,dbpassword/) }
 end


### PR DESCRIPTION
### Description

This PR adds a helper method to list items in a vault. Per the below referenced issue, `data_bag()` was suggested to be used to list items in a vault. However, that method also returns the keys in addition to the items, forcing users to parse the list and remove the keys. The new method essentially does this for users to keep their code bases cleaner.

### Issues Resolved

#66 

### Check List

- [Y] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [Y] New functionality includes testing.
- [Y] New functionality has been documented in the README if applicable
- [Y] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
