### PR TITLE
Fix Chef14 compatibility for chef_vault_secret resource

### DIFF
--- a/resources/secret.rb
+++ b/resources/secret.rb
@@ -48,7 +48,7 @@ action :create do
 end
 
 action :create_if_missing do
-  action_create if current_value.nil?
+  action_create if current_resource.nil?
 end
 
 action :delete do


### PR DESCRIPTION
### Description

`current_value` is no longer the correct function to use in custom resources in Chef 14 and above. This pull request replaces that call in the `chef_vault_secret` resource with the correct function to use, `current_resource`.

See the comment on #70 for information. 

### Issues Resolved

Resolves #70 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
