### PR TITLE
Add logic to use 3.x gem on chef 12

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ source_url 'https://github.com/chef-cookbooks/chef-vault'
 issues_url 'https://github.com/chef-cookbooks/chef-vault/issues'
 chef_version '>= 12.9'
 
-if %x(chef-client --version).split[1].to_f < 13
+if `chef-client --version`.split[1].to_f < 13
   gem 'chef-vault', '< 4.0'
 else
   gem 'chef-vault'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,12 +3,16 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs the chef-vault gem and provides chef_vault_item recipe helper'
-version '3.1.1'
+version '3.1.2'
 
 source_url 'https://github.com/chef-cookbooks/chef-vault'
 issues_url 'https://github.com/chef-cookbooks/chef-vault/issues'
 chef_version '>= 12.9'
 
-gem 'chef-vault'
+if %x(chef-client --version).split[1].to_f < 13
+  gem 'chef-vault', '< 4.0'
+else
+  gem 'chef-vault'
+end
 
 supports 'any'


### PR DESCRIPTION
Signed-off-by: Sean Milbrath <Sean.Milbrath@Cerner.com>
### Description

Due to the release of the 4.0.1 chef-vault ruby gem, which now has a ruby requirement of 2.4+, this cookbook is broken for anyone using Chef 12. This logic checks which chef-client version is being run, and selects a gem version that is appropriate.

I have tested this change in our own dev environment as well as performed [kitchen testing](https://github.com/chef-cookbooks/chef-vault/files/4013411/chef-vault.txt).

### Issues Resolved
#74 
### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
