### PR TITLE
pin chef-vault gem version for continued chef 12 support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,12 +3,12 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs the chef-vault gem and provides chef_vault_item recipe helper'
-version '3.1.1'
+version '3.1.2'
 
 source_url 'https://github.com/chef-cookbooks/chef-vault'
 issues_url 'https://github.com/chef-cookbooks/chef-vault/issues'
 chef_version '>= 12.9'
 
-gem 'chef-vault'
+gem 'chef-vault', '= 4.0.0'
 
 supports 'any'


### PR DESCRIPTION
### Description

chef-vault gem release `4.0.1` removed support for ruby version `<2.4`, because this cookbook still claims that it supports chef versions `>= 12.9` this cookbook's gem dependency should be pinned to the latest release that would support chef 12's ruby version

### Issues Resolved

N/A

### Check List

threw up the PR quick ill check these after this opens. not sure if i need to do the DCO thing, let me know if i do

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
