### PR TITLE
Fix chef_vault_secret idempotent behavior

### DIFF
--- a/resources/secret.rb
+++ b/resources/secret.rb
@@ -17,6 +17,8 @@ load_current_value do
     clients item.get_clients
     admins item.get_admins
     search item.search
+  rescue ChefVault::Exceptions::SecretDecryption
+    current_value_does_not_exist!
   rescue ChefVault::Exceptions::KeysNotFound
     current_value_does_not_exist!
   rescue Net::HTTPServerException => e

--- a/test/fixtures/cookbooks/test/recipes/chef_vault_secret.rb
+++ b/test/fixtures/cookbooks/test/recipes/chef_vault_secret.rb
@@ -1,6 +1,6 @@
 # Author:: Joshua Timberman <joshua@chef.io>
 #
-# Copyright:: 2014-2019, Chef Software, Inc. <legal@chef.io>
+# Copyright:: 2014-2020, Chef Software Inc. <legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,22 @@ chef_vault_secret 'clean-energy' do
   search '*:*'
 end
 
+# ensure we get some kind of idempotent behavior
+chef_vault_secret 'clean-energy' do
+  data_bag 'green'
+  raw_data('auth' => 'Forged in a mold')
+  admins 'hydroelectric'
+  search '*:*'
+end
+
+chef_vault_secret 'dirty-energy' do
+  environment '_default'
+  data_bag 'green'
+  raw_data('auth' => 'carbon-credits')
+  admins 'hydroelectric'
+end
+
+# ensure we get some kind of idempotent behavior
 chef_vault_secret 'dirty-energy' do
   environment '_default'
   data_bag 'green'


### PR DESCRIPTION
This causes the idempotent behavior of chef_vault_secret to stop failing when it can't decrypt the key.  It does mean that it is actually not idempotent and will re-create it every time.  Actually getting idempotent behavior to work correctly will be tough.